### PR TITLE
Enable optional postgis extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,12 @@ Builds only a single binary for a specified platform and architecture.
 
 `./gradlew clean install -Pversion=10.6.0 -PpgVersion=10.6 -ParchName=arm64v8 -PdistName=alpine`
 
+It is also possible to include the PostGIS extension by passing the `postgisVersion` parameter, e.g. `-PpostgisVersion=2.5.2`. Note that this option is not (yet) available for Windows and Mac OS platforms.
+
 Optional parameters:
+- *postgisVersion*
+  - default value: unset
+  - supported values: a postgis version number (only 2.5.2+, 2.4.7+, 2.3.9+ versions are supported)
 - *archName*
   - default value: `amd64`
   - supported values: `amd64`, `i386`, `arm32v6`, `arm32v7`, `arm64v8`, `ppc64le`

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ ext {
 
     pgVersionParam = project.findProperty('pgVersion') ?: ("${project.version}" - '-SNAPSHOT')
     pgBinVersionParam = project.findProperty('pgBinVersion') ?: "${pgVersionParam}-1"
+    postgisVersion = project.findProperty('postgisVersion') ?: ''
     archNameParam = project.findProperty('archName') ?: ''
     distNameParam = project.findProperty('distName') ?: ''
     dockerImageParam = project.findProperty('dockerImage') ?: ''
@@ -28,6 +29,7 @@ allprojects {
     apply plugin: 'com.jfrog.bintray'
 
     group 'io.zonky.test.postgres'
+    version += postgisVersion ? "-postgis-$postgisVersion" : ''
     archivesBaseName = 'embedded-postgres-binaries'
     sourceCompatibility = 1.6
 
@@ -111,7 +113,7 @@ def alpineVariants = [
 ]
 
 project(':repacked-platforms') {
-    if (!distNameParam && !archNameParam && !dockerImageParam) {
+    if (!distNameParam && !archNameParam && !dockerImageParam && !postgisVersion) {
         task generateRepackedPostgresBundles(group: "repacking", type: Exec, dependsOn: validateInputs) {
             inputs.property('pgBinVersionParam', pgBinVersionParam)
 
@@ -135,7 +137,7 @@ project(':repacked-platforms') {
 }
 
 project(':debian-platforms') {
-    if (!distNameParam && !archNameParam && !dockerImageParam) {
+    if (!distNameParam && !archNameParam && !dockerImageParam && !postgisVersion) {
         debianPlatforms.each { platform ->
             task "generate${platform.arch.capitalize()}DebianPostgresBundle"(group: "build (${platform.arch})", type: LazyExec, dependsOn: [validateInputs, prepareQemuExecutables]) {
                 def qemuBindings = { resolveQemuBindings() }
@@ -172,7 +174,7 @@ project(':debian-platforms') {
 
 alpineVariants.each { variant ->
     project(":alpine${variant.name ? '-' + variant.name : ''}-platforms") {
-        if (!distNameParam && !archNameParam && !dockerImageParam && variant.enabled) {
+        if (!distNameParam && !archNameParam && !dockerImageParam && !postgisVersion && variant.enabled) {
             alpinePlatforms.each { platform ->
 
                 task "generate${platform.arch.capitalize()}Alpine${variant.name.capitalize()}PostgresBundle"(group: "build (${platform.arch})", type: LazyExec, dependsOn: [validateInputs, prepareQemuExecutables]) {
@@ -210,7 +212,7 @@ alpineVariants.each { variant ->
 }
 
 project(':custom-debian-platform') {
-    if (!distNameParam && (archNameParam || dockerImageParam)) {
+    if (!distNameParam && (archNameParam || dockerImageParam || postgisVersion)) {
         def archName = archNameParam ?: 'amd64'
 
         task generateCustomDebianPostgresBundle(group: 'build (custom)', type: LazyExec, dependsOn: [validateInputs, prepareQemuExecutables]) {
@@ -223,17 +225,25 @@ project(':custom-debian-platform') {
                 println "dockerImage:   ${dockerImage()}"
                 println "qemuBindings:  ${qemuBindings()}"
                 println ''
+
+                if (postgisVersion) {
+                    println '===== Extensions ====='
+                    println "postgisVersion: $postgisVersion"
+                    println '======================'
+                    println ''
+                }
             }
 
             inputs.property('pgVersion', pgVersionParam)
             inputs.property('archName', archName)
             inputs.property('dockerImage', dockerImage)
+            inputs.property('postgisVersion', postgisVersion)
 
             inputs.file("$rootDir/repack-postgres-debian.sh")
             outputs.dir("$temporaryDir/bundle")
 
             workingDir temporaryDir
-            commandLine "$rootDir/repack-postgres-debian.sh", '-v', "$pgVersionParam", '-i', dockerImage, '-o', qemuBindings
+            commandLine "$rootDir/repack-postgres-debian.sh", '-v', "$pgVersionParam", '-i', dockerImage, '-g', postgisVersion, '-o', qemuBindings
         }
 
         task customDebianJar(group: 'build (custom)', type: Jar) {
@@ -262,17 +272,25 @@ alpineVariants.each { variant ->
                     println "dockerImage:   ${dockerImage()}"
                     println "qemuBindings:  ${qemuBindings()}"
                     println ''
+
+                    if (postgisVersion) {
+                        println '===== Extensions ====='
+                        println "postgisVersion: $postgisVersion"
+                        println '======================'
+                        println ''
+                    }
                 }
 
                 inputs.property('pgVersion', pgVersionParam)
                 inputs.property('archName', archName)
                 inputs.property('dockerImage', dockerImage)
+                inputs.property('postgisVersion', postgisVersion)
 
                 inputs.file("$rootDir/repack-postgres-alpine.sh")
                 outputs.dir("$temporaryDir/bundle")
 
                 workingDir temporaryDir
-                commandLine "$rootDir/repack-postgres-alpine.sh", '-v', "$pgVersionParam", '-i', dockerImage, '-o', qemuBindings, "${variant.opt}"
+                commandLine "$rootDir/repack-postgres-alpine.sh", '-v', "$pgVersionParam", '-i', dockerImage, '-g', postgisVersion, '-o', qemuBindings, "${variant.opt}"
             }
 
             task "customAlpine${variant.name.capitalize()}Jar"(group: 'build (custom)', type: Jar) {

--- a/repack-postgres-debian.sh
+++ b/repack-postgres-debian.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 DOCKER_OPTS=
+POSTGIS_VERSION=
 LITE_OPT=false
 
-while getopts "v:i:o:l" opt; do
+while getopts "v:i:g:o:l" opt; do
     case $opt in
     v) VERSION=$OPTARG ;;
     i) IMG_NAME=$OPTARG ;;
+    g) POSTGIS_VERSION=$OPTARG ;;
     o) DOCKER_OPTS=$OPTARG ;;
     l) LITE_OPT=true ;;
     \?) exit 1 ;;
@@ -22,6 +24,11 @@ fi
 if [[ "$VERSION" == 9.* ]] && [[ "$LITE_OPT" == true ]] ; then
   echo "Lite option is supported only for PostgreSQL 10 or later!" && exit 1;
 fi
+
+PROJ_VERSION=6.0.0
+PROJ_DATUMGRID_VERSION=1.8
+GEOS_VERSION=3.7.2
+GDAL_VERSION=2.4.1
 
 ICU_ENABLED=$([[ ! "$VERSION" == 9.* ]] && [[ ! "$LITE_OPT" == true ]] && echo true || echo false);
 
@@ -84,10 +91,54 @@ docker run -i --rm -v ${TRG_DIR}:/usr/local/pg-dist $DOCKER_OPTS $IMG_NAME /bin/
     && make install-world \
     && make -C contrib install \
     \
+    && if [ -n "$POSTGIS_VERSION" ]; then \
+      apt-get install -y --no-install-recommends curl libjson-c-dev libsqlite3-0 libsqlite3-dev sqlite3 unzip \
+      && mkdir -p /usr/src/proj \
+        && curl -sL 'http://download.osgeo.org/proj/proj-$PROJ_VERSION.tar.gz' | tar -xzf - -C /usr/src/proj --strip-components 1 \
+        && cd /usr/src/proj \
+        && curl -sL 'http://download.osgeo.org/proj/proj-datumgrid-$PROJ_DATUMGRID_VERSION.zip' >proj-datumgrid.zip \
+        && unzip -o proj-datumgrid.zip -d data\
+        && curl -sL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=b8ee5f79949d1d40e8820a774d813660e1be52d3' >config.guess \
+        && curl -sL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=b8ee5f79949d1d40e8820a774d813660e1be52d3' >config.sub \
+        && ./configure --disable-static --prefix=/usr/local/pg-build \
+        && make -j\$(nproc) \
+        && make install \
+      && mkdir -p /usr/src/geos \
+        && curl -sL 'http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2' | tar -xjf - -C /usr/src/geos --strip-components 1 \
+        && cd /usr/src/geos \
+        && curl -sL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=b8ee5f79949d1d40e8820a774d813660e1be52d3' >config.guess \
+        && curl -sL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=b8ee5f79949d1d40e8820a774d813660e1be52d3' >config.sub \
+        && ./configure --disable-static --prefix=/usr/local/pg-build \
+        && make -j\$(nproc) \
+        && make install \
+      && mkdir -p /usr/src/gdal \
+        && curl -sL 'http://download.osgeo.org/gdal/$GDAL_VERSION/gdal-$GDAL_VERSION.tar.xz' | tar -xJf - -C /usr/src/gdal --strip-components 1 \
+        && cd /usr/src/gdal \
+        && curl -sL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=b8ee5f79949d1d40e8820a774d813660e1be52d3' >config.guess \
+        && curl -sL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=b8ee5f79949d1d40e8820a774d813660e1be52d3' >config.sub \
+        && ./configure --disable-static --prefix=/usr/local/pg-build \
+        && make -j\$(nproc) \
+        && make install \
+      && mkdir -p /usr/src/postgis \
+        && curl -sL 'http://postgis.net/stuff/postgis-$POSTGIS_VERSION.tar.gz' | tar -xzf - -C /usr/src/postgis --strip-components 1 \
+        && cd /usr/src/postgis \
+        && curl -sL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=b8ee5f79949d1d40e8820a774d813660e1be52d3' >config.guess \
+        && curl -sL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=b8ee5f79949d1d40e8820a774d813660e1be52d3' >config.sub \
+        && ./configure \
+            --prefix=/usr/local/pg-build \
+            --with-pgconfig=/usr/local/pg-build/bin/pg_config \
+            --with-geosconfig=/usr/local/pg-build/bin/geos-config \
+            --with-projdir=/usr/local/pg-build \
+            --with-gdalconfig=/usr/local/pg-build/bin/gdal-config \
+        && make -j\$(nproc) \
+        && make install \
+    ; fi \
+    \
     && cd /usr/local/pg-build \
     && cp /lib/*/libz.so.1 /lib/*/libuuid.so.1 /lib/*/liblzma.so.5 /usr/lib/*/libxml2.so.2 /usr/lib/*/libxslt.so.1 ./lib \
     && cp /lib/*/libssl.so.1.0.0 /lib/*/libcrypto.so.1.0.0 ./lib || cp /usr/lib/*/libssl.so.1.0.0 /usr/lib/*/libcrypto.so.1.0.0 ./lib \
     && if [ "$ICU_ENABLED" = true ]; then cp --no-dereference /usr/lib/*/libicudata.so* /usr/lib/*/libicuuc.so* /usr/lib/*/libicui18n.so* ./lib; fi \
+    && if [ -n "$POSTGIS_VERSION" ]; then cp --no-dereference /lib/*/libjson-c.so* /usr/lib/*/libsqlite3.so* ./lib ; fi \
     && find ./bin -type f \( -name 'initdb' -o -name 'pg_ctl' -o -name 'postgres' \) -print0 | xargs -0 -n1 patchelf --set-rpath '\$ORIGIN/../lib' \
     && find ./lib -maxdepth 1 -type f -name '*.so*' -print0 | xargs -0 -n1 patchelf --set-rpath '\$ORIGIN' \
     && find ./lib/postgresql -maxdepth 1 -type f -name '*.so*' -print0 | xargs -0 -n1 patchelf --set-rpath '\$ORIGIN/..' \


### PR DESCRIPTION
Configure build and deployment of secondary artifacts with a "postgis"
classifier, by specifying "-PpostgisVersion=x.y.z" during the build.

Fixes #4