### PR TITLE
Upgrade postgres versions to the latest ones

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        postgres: [13.2, 12.6, 11.11, 10.16, 9.6.21, 9.5.25]
+        postgres: [13.3, 12.7, 11.12, 10.17, 9.6.22]
     steps:
       - name: Checkout project
         uses: actions/checkout@v1
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        postgres: [13.2, 12.6, 11.11, 10.16, 9.6.21, 9.5.25]
+        postgres: [13.3, 12.7, 11.12, 10.17, 9.6.22]
     steps:
       - name: Checkout project
         uses: actions/checkout@v1
@@ -46,7 +46,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        postgres: [13.2, 12.6, 11.11, 10.16, 9.6.21]
+        postgres: [13.3, 12.7, 11.12, 10.17, 9.6.22]
     steps:
       - name: Checkout project
         uses: actions/checkout@v1
@@ -61,7 +61,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        postgres: [13.2, 12.6, 11.11, 10.16, 9.6.21, 9.5.25]
+        postgres: [13.3, 12.7, 11.12, 10.17, 9.6.22]
     steps:
       - name: Checkout project
         uses: actions/checkout@v1


### PR DESCRIPTION
Upgrade postgres versions to the latest ones.

See https://www.postgresql.org/support/versioning/ and https://www.postgresql.org/about/news/postgresql-133-127-1112-1017-and-9622-released-2210/