### PR TITLE
docs: add theseus-rs/postgresql-embedded to projects using binaries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ However, with a little effort, the embedded binaries can also be integrated with
 * [zonkyio/embedded-postgres](https://github.com/zonkyio/embedded-postgres) (Java)
 * [hgschmie/pg-embedded](https://github.com/hgschmie/pg-embedded) (Java)
 * [fergusstrange/embedded-postgres](https://github.com/fergusstrange/embedded-postgres) (Go)
+* [theseus-rs/postgresql-embedded](https://github.com/theseus-rs/postgresql-embedded) (Rust)
 * [faokunega/pg-embed](https://github.com/faokunega/pg-embed) (Rust)
 * [leinelissen/embedded-postgres](https://github.com/leinelissen/embedded-postgres) (NodeJS)
 


### PR DESCRIPTION
Thanks you for all your effort in producing / maintaining the PostgreSQL binaries!  I have recently updated [theseus-rs/postgresql-embedded](https://github.com/theseus-rs/postgresql-embedded) to support installing the archives from this project.  I believe the other Rust project on your list [faokunega/pg-embed](https://github.com/faokunega/pg-embed) may no longer be maintained; this is what prompted the creation of a new project.