### PR TITLE
Fix macOS workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 15
+      - name: Install psql executables
+        run: |
+          brew update
+          brew install postgresql
       - name: Test PostgreSQL bundle
         run: ./gradlew :repacked-platforms:testAmd64DarwinJar -Pversion=${{ matrix.postgres }}-TEST -PpgVersion=${{ matrix.postgres }}
         timeout-minutes: 10


### PR DESCRIPTION
There are no PSQL executables in the latest macOS image anymore.